### PR TITLE
run from outside repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ ENV SHOW_PACKS Yes
 ENV FORCE_CPU No
 ENV AID_APP_ID BaseAidApp
 
-ENV PYTHONPATH .
+# this variable should contain the path to the `basic_inference_server`
+# repository directory, since the code contains a lot of magic tricks that
+# rely on searching in the repository's directories 
+
+# this variable is used as cwd when launching the server inside the container
+ENV DEFAULT_PYTHON_PATH "."
 
 EXPOSE 5001-5015/tcp
 
-CMD ["python", "run_gateway.py"]
+CMD python run_gateway.py --default_python_path $DEFAULT_PYTHON_PATH

--- a/__init__.py
+++ b/__init__.py
@@ -15,5 +15,4 @@ written permission from the author.
 
 """
 
-from .basic_inference_server import Logger
-from .basic_inference_server.model_server.gateway import FlaskGateway, get_packages
+from .basic_inference_server import Logger, FlaskGateway, get_packages

--- a/basic_inference_server/model_server/gateway/gateway.py
+++ b/basic_inference_server/model_server/gateway/gateway.py
@@ -33,7 +33,7 @@ from ...generic_obj import BaseObject
 from ...logger_mixins.serialization_json_mixin import NPJson
 from ..request_utils import get_api_request_body, MSCT
 
-
+### WHAT IS THIS ?? ###
 from ...model_server import run_server_module
 
 from ver import __VER__
@@ -68,6 +68,7 @@ class FlaskGateway(BaseObject):
                workers_suffix=None,
                host=None,
                port=None,
+               default_python_path=None,
                first_server_port=None,
                server_execution_path=None,
                **kwargs
@@ -117,6 +118,7 @@ class FlaskGateway(BaseObject):
     self._server_execution_path = server_execution_path or MSCT.RULE_DEFAULT
     self._workers_location = workers_location
     self._workers_suffix = workers_suffix
+    self._default_python_path = default_python_path
 
     self._first_server_port = first_server_port or self._port + 1
     self._current_server_port = self._first_server_port
@@ -323,7 +325,7 @@ class FlaskGateway(BaseObject):
     msg = "Creating server `{} <{}>` at {}:{}{}".format(server_name, server_class, host, port, execution_path)
     self.P(msg, color='g')
     self._create_notification('log', msg)
-    str_cmd = os.path.relpath(run_server_module.__file__)
+    str_cmd = os.path.join(*os.path.relpath(run_server_module.__file__).split(os.sep)[-3:])
     self.P("Running '{}'".format(str_cmd))
     popen_args = [
       'python',
@@ -344,6 +346,7 @@ class FlaskGateway(BaseObject):
     
     process = subprocess.Popen(
       popen_args,
+      cwd=self._default_python_path,
     )
 
     self._servers[server_name] = {

--- a/basic_inference_server/model_server/run_server.py
+++ b/basic_inference_server/model_server/run_server.py
@@ -9,8 +9,14 @@ sys.path.append(cwd)
 import argparse
 import json
 
-from basic_inference_server import Logger
-from basic_inference_server.model_server import FlaskModelServer
+try:
+  from ..public_logger import Logger
+except ImportError:
+  from basic_inference_server.public_logger import Logger
+try:
+  from . import FlaskModelServer
+except ImportError:
+  from basic_inference_server.model_server import FlaskModelServer
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()

--- a/run_gateway.py
+++ b/run_gateway.py
@@ -22,8 +22,7 @@ import platform
 
 import argparse
 
-from basic_inference_server import Logger
-from basic_inference_server import FlaskGateway, get_packages
+from basic_inference_server import Logger, FlaskGateway, get_packages
 
 from time import sleep
 
@@ -63,12 +62,18 @@ if __name__ == '__main__':
   parser.add_argument(
     '--port', type=int, default=5002
   )
+  
+  parser.add_argument(
+    '--default_python_path', type=str, default='.',
+    help="The path used as `PYTHONPATH` when calling `python run_server.py`"
+  )
 
   args = parser.parse_args()
   base_folder = args.base_folder
   app_folder = args.app_folder
   host = args.host
   port = args.port
+  default_python_path = args.default_python_path
 
   ### Attention! config_file should contain the configuration for each endpoint; 'NR_WORKERS' and upstream configuration
   log = Logger(
@@ -109,6 +114,7 @@ if __name__ == '__main__':
     workers_suffix='Worker',
     host=host,
     port=port,
+    default_python_path=default_python_path,
     #first_server_port=5020,
     server_execution_path='/run'
   )


### PR DESCRIPTION
Am facut niste artificii, niste magii, niste hack-uri mai bine spus, ca sa putem sa rulam scripturile din afara folderului de repo. 

Pe scurt, simulam rularea scriptului din interior ca si cand ar fi rulat din folderul repo-ului, adica atunci cand facem popen, ii schimbam `current working directory`.

Am modificat niste importuri, nu afecteaza asa tare codul efectiv, dar e ciudat, spre aiurea, organizat. se fac importuri relative cu 3 foldere in spate (vezi comentariul), toata lumea stie de toata lumea, e weird, daca ma intrebi pe mine.

Ar fi mai frumos sa expunem clasa Logger in afara intregului modul, ca sa o importam simplu (import Logger), si nu prin 1000 de moduri si prin cai, cand relative, cand absolute.

Ca de fapt asta e problema :)) cum am zis mai sus, toata lumea are nevoie de toata lumea, toti pot sa se acceseze pe toti, si acest aspect nu ofera separabilitate.

Am gasit un mod de a face importuri lazy, dar introduce o gramada de alte probleme si trebuie testat muuuult mai bine, tratate toate cazurile de load, e bataie de cap. 